### PR TITLE
#261 - Refactor class gui::views::View to get it as a c++20 module (cpp)

### DIFF
--- a/avt_cpp/avt_cpp.vcxproj
+++ b/avt_cpp/avt_cpp.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="gui\views\control_view.cpp" />
     <ClCompile Include="gui\views\control_view.ixx" />
     <ClCompile Include="gui\views\view.cpp" />
+    <ClCompile Include="gui\views\view.ixx" />
     <ClCompile Include="interactions\app_automaton.ixx" />
     <ClCompile Include="interactions\mouse_control.cpp" />
     <ClCompile Include="interactions\mouse_control.ixx" />
@@ -221,7 +222,6 @@
     <ClCompile Include="video\frame.ixx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="gui\views\view.h" />
     <ClInclude Include="utils\types.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/avt_cpp/avt_cpp.vcxproj.filters
+++ b/avt_cpp/avt_cpp.vcxproj.filters
@@ -201,12 +201,12 @@
     <ClCompile Include="gui\views\control_view.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="gui\views\view.ixx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="utils\types.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="gui\views\view.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/avt_cpp/avt_unit_tests_main.h
+++ b/avt_cpp/avt_unit_tests_main.h
@@ -46,9 +46,9 @@ SOFTWARE.
 //import gui.fonts.bold_font;
 //import gui.fonts.italic_font;
 //import gui.fonts.bold_italic_font;
-//import unit_tests.gui.items.test_view;
+//import unit_tests.gui.views.test_view;
 
-import unit_tests.gui.test_avt_window;
+//import unit_tests.gui.test_avt_window;
 
 
 //===========================================================================
@@ -71,8 +71,8 @@ int main()
     //avt::unit_tests::gui::shapes::test_point();
     //avt::unit_tests::gui::shapes::test_line();
     //avt::unit_tests::gui::shapes::test_rect();
-    //avt::unit_tests::gui::items::test_view();
-    avt::unit_tests::gui::test_main_window();
+    //avt::unit_tests::gui::views::test_view();
+    //avt::unit_tests::gui::test_main_window();
 
 
     std::cout << "\n >>>>>>>>>>   EVERYTHING WENT FINE   <<<<<<<<<<\n\n";

--- a/avt_cpp/gui/avt_window.cpp
+++ b/avt_cpp/gui/avt_window.cpp
@@ -32,8 +32,6 @@ module;
 #include <opencv2/core/cvstd.hpp>
 #include <opencv2/highgui.hpp>
 
-#include "gui/views/view.h"
-
 
 module gui.avt_window;
 
@@ -44,7 +42,7 @@ import video.frame;
 import mtmp.mutex;
 import utils.rgb_color;
 import utils.size;
-
+import gui.views.view;
 
 
 //===========================================================================

--- a/avt_cpp/gui/avt_window.ixx
+++ b/avt_cpp/gui/avt_window.ixx
@@ -33,8 +33,6 @@ module;
 #include <opencv2/core/cvstd.hpp>
 #include <opencv2/highgui.hpp>
 
-#include "gui/views/view.h"
-
 
 export module gui.avt_window;
 
@@ -45,6 +43,7 @@ import video.frame;
 import mtmp.mutex;
 import utils.rgb_color;
 import utils.size;
+import gui.views.view;
 
 
 //===========================================================================

--- a/avt_cpp/gui/views/control_view.cpp
+++ b/avt_cpp/gui/views/control_view.cpp
@@ -32,8 +32,9 @@ module;
 
 #include <opencv2/core/cvstd.hpp>
 #include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
 
-#include "gui/views/view.h"
+#include "utils/types.h"
 
 
 module gui.views.control_view;
@@ -45,6 +46,7 @@ import gui.fonts.font;
 import mtmp.mutex;
 import utils.rgb_color;
 import utils.size;
+import gui.views.view;
 
 
 //===========================================================================

--- a/avt_cpp/gui/views/control_view.ixx
+++ b/avt_cpp/gui/views/control_view.ixx
@@ -33,7 +33,7 @@ module;
 #include <opencv2/core/cvstd.hpp>
 #include <opencv2/highgui.hpp>
 
-#include "gui/views/view.h"
+#include "utils/types.h"
 
 
 export module gui.views.control_view;
@@ -47,6 +47,8 @@ import mtmp.mutex;
 import utils.rgb_color;
 import utils.size;
 import mtmp.timer;
+import utils;
+import gui.views.view;
 
 
 //===========================================================================

--- a/avt_cpp/gui/views/view.cpp
+++ b/avt_cpp/gui/views/view.cpp
@@ -23,20 +23,25 @@ SOFTWARE.
 */
 
 //===========================================================================
+module;
+
 #include <algorithm>
+
+#include <opencv2/imgproc.hpp>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/core/types.hpp>
 
 #include "utils/types.h"
 
-#include "gui/views/view.h"
 
+module gui.views.view;
 
 import avt.config;
 import utils.coords2d;
 import utils.rgb_color;
 import utils.size;
 import utils;
+import gui.views.view;
 
 
 //===========================================================================

--- a/avt_cpp/gui/views/view.ixx
+++ b/avt_cpp/gui/views/view.ixx
@@ -1,4 +1,3 @@
-#pragma once
 /*
 MIT License
 
@@ -24,6 +23,8 @@ SOFTWARE.
 */
 
 //===========================================================================
+module;
+
 #include <algorithm>
 
 #include <opencv2/imgproc.hpp>
@@ -31,6 +32,9 @@ SOFTWARE.
 #include <opencv2/core/types.hpp>
 
 #include "utils/types.h"
+
+
+export module gui.views.view;
 
 
 import avt.config;
@@ -41,7 +45,7 @@ import utils;
 
 
 //===========================================================================
-namespace avt::gui::views
+export namespace avt::gui::views
 {
     //=======================================================================
     /** @brief The base class for all displayed items. */
@@ -54,8 +58,8 @@ namespace avt::gui::views
     public:
         //---   Wrappers   --------------------------------------------------
         using MyBaseType = avt::ImageType;        //!< wrapper to the base class
-        using PosType    = avt::utils::Coords2D;  //!< wrapper to the Coords2D class
-        using SizeType   = avt::utils::Size;      //!< wrapper to the Size class
+        using PosType = avt::utils::Coords2D;  //!< wrapper to the Coords2D class
+        using SizeType = avt::utils::Size;      //!< wrapper to the Size class
 
 
         //---   Constructors / Destructors   --------------------------------
@@ -63,52 +67,52 @@ namespace avt::gui::views
         template<typename X, typename Y, typename H, typename W>
             requires std::is_arithmetic_v<X>&& std::is_arithmetic_v<Y>&& std::is_arithmetic_v<H>&& std::is_arithmetic_v<W>
         inline View(View* p_parent_view,
-                    const X x,
-                    const Y y,
-                    const W width,
-                    const H height,
-                    const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
+            const X x,
+            const Y y,
+            const W width,
+            const H height,
+            const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
             : MyBaseType(height, width, (cv::Vec3b)bg_color),
-              p_parent_view(p_parent_view),
-              pos(x, y)
+            p_parent_view(p_parent_view),
+            pos(x, y)
         {}
 
         /** @brief Value Constructor (1 pos + 1 size + 1 color). */
         inline View(View* p_parent_view,
-                    const avt::utils::Coords2D& top_left,
-                    const avt::utils::Size& size,
-                    const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
+            const avt::utils::Coords2D& top_left,
+            const avt::utils::Size& size,
+            const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
             : MyBaseType(size.height, size.width, (cv::Vec3b)bg_color),
-              p_parent_view(p_parent_view),
-              pos(top_left)
+            p_parent_view(p_parent_view),
+            pos(top_left)
         {}
 
         /** @brief Value Constructor (1 rect + 1 color). */
         inline View(View* p_parent_view,
-                    const avt::CVRect& rect,
-                    const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
+            const avt::CVRect& rect,
+            const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
             : MyBaseType(rect.height, rect.width, (cv::Vec3b)bg_color),
-              p_parent_view(p_parent_view),
-              pos(rect.tl())
+            p_parent_view(p_parent_view),
+            pos(rect.tl())
         {}
 
         /** @brief Main View Constructor (2 scalars + 1 color). */
         template<typename H, typename W>
-            requires std::is_arithmetic_v<H> && std::is_arithmetic_v<W>
+            requires std::is_arithmetic_v<H>&& std::is_arithmetic_v<W>
         inline View(const W width,
-                    const H height,
-                    const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
+            const H height,
+            const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
             : MyBaseType(height, width, (cv::Vec3b)bg_color),
-              p_parent_view(nullptr),
-              pos(0, 0)
+            p_parent_view(nullptr),
+            pos(0, 0)
         {}
 
         /** @brief Value Constructor (1 size + 1 color). */
         inline View(const avt::utils::Size& size,
-                    const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
+            const RGBColor& bg_color = avt::config::DEFAULT_BACKGROUND) noexcept
             : MyBaseType(size.height, size.width, (cv::Vec3b)bg_color),
-              p_parent_view(nullptr),
-              pos(0, 0)
+            p_parent_view(nullptr),
+            pos(0, 0)
         {}
 
         /** @brief Default Empty Constructor. */
@@ -213,7 +217,7 @@ namespace avt::gui::views
 
         /** @brief Sets position and parent view (2 coordinates). */
         template<typename X, typename Y>
-            requires std::is_arithmetic_v<X> && std::is_arithmetic_v<Y>
+            requires std::is_arithmetic_v<X>&& std::is_arithmetic_v<Y>
         inline void set(const X x_, const Y y_, View* p_parent_view_ = nullptr)
         {
             move_at(x_, y_);
@@ -261,14 +265,14 @@ namespace avt::gui::views
 
         //---   Attributes   ------------------------------------------------
         PosType pos;            //!< the position in the parent view of this view's top-left corner 
-        View*   p_parent_view;  //!< a pointer to this view's parent view
+        View* p_parent_view;  //!< a pointer to this view's parent view
 
 
     private:
         /** @brief Evaluates the clipped size of this view when displayed in a frame. */
-        avt::utils::Size m_clipping_size(const PosType&          abs_pos,
-                                         const avt::utils::Size& size,
-                                         avt::ImageType&         image) const noexcept;
+        avt::utils::Size m_clipping_size(const PosType& abs_pos,
+            const avt::utils::Size& size,
+            avt::ImageType& image) const noexcept;
 
         /** @brief Evaluates the absolute position of this view within the root View. */
         avt::utils::Coords2D m_get_abs_pos(const View* p_current_view) const noexcept;

--- a/avt_cpp/unit_tests/gui/test_avt_window.ixx
+++ b/avt_cpp/unit_tests/gui/test_avt_window.ixx
@@ -34,7 +34,6 @@ module;
 #include <opencv2/core/types.hpp>
 
 #include "utils/types.h"
-#include "gui/views/view.h"
 
 
 export module unit_tests.gui.test_avt_window;
@@ -42,6 +41,7 @@ export module unit_tests.gui.test_avt_window;
 
 import gui.avt_window;
 import avt.config;
+import gui.views.view;
 
 
 //===========================================================================

--- a/avt_cpp/unit_tests/gui/views/test_view.ixx
+++ b/avt_cpp/unit_tests/gui/views/test_view.ixx
@@ -30,7 +30,6 @@ module;
 #include <opencv2/core/types.hpp>
 
 #include "utils/types.h"
-#include "gui/views/view.h"
 
 
 export module unit_tests.gui.views.test_view;
@@ -40,6 +39,7 @@ import utils.coords2d;
 import video.frame;
 import utils.rgb_color;
 import utils.size;
+import gui.views.view;
 
 
 //===========================================================================


### PR DESCRIPTION
Finally solved the compiler cl1 internal error encountered on erroneous implementation of class gui::views::View.
The error was due to cycli references of import modules.